### PR TITLE
Fix Submission Reload and Add Theme Check on Load

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                         rows="10"
                     ></textarea>
                     <div class="error_tip"></div>
-                    <button class="button" type="submit" onclick="return formSend();">SEND MESSAGE</button>
+                    <button class="button" type="submit" onclick="formSend(event);">SEND MESSAGE</button>
                 </form>
             </div>
         </div>

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -200,6 +200,15 @@ const themeMode = () => {
     toggle.onclick = () => {
         toggle.checked ? document.body.classList.add('dark_mode') : document.body.classList.remove('dark_mode')
     }
+
+    // read the initial theme from querystring, if avaliable:
+    const params = new URLSearchParams(window.location.search)
+    const theme = params.get('theme')
+    if (theme == 'dark')
+    {// the theme is dark mode (non-default), set the checkbox to toggled and add dark mode to the classlist:
+        document.body.classList.add('dark_mode')
+        toggle.checked = true
+    }
 }
 
 

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -362,7 +362,10 @@ const formValidate = () => {
     }
 }
 
-const formSend = async () => {
+const formSend = async (event) => {
+    // prevent form page navigation
+    if (event) { event.preventDefault(); }
+
     const message = document.getElementById('contact_message').value.trim()
     const ticketData = {
         source: 'ATLAS',
@@ -382,9 +385,6 @@ const formSend = async () => {
     .catch((error) => {
         // handle error while creating user ticket here
     });
-    
-    // prevent form page navigation
-    return false
 }
 
 const showPopup = () => {


### PR DESCRIPTION
`20c979c - 2021-08-07 17:49 - Use alternate method to prevent page-level refresh`

This change will pass the `event` object to the handling function `formSend` which will use `event.preventDefault` to prevent default form submission which was causing a page reload. See <https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault>

---

`aa6bd1e - 2021-08-07 18:08 - Get and use correct theme from querystring during initial setup`

This change adds a feature for detecting and applying a theme (light or dark) passed in under the querystring parameter `theme`. If the parameter is `dark` then dark mode will be applied in the document class and the theme checkbox will be toggled accordingly. If the parameter is anything else, or if it is not present at all, then the theme will be left as `light` and nothing will change.